### PR TITLE
Add 512 app icon

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -83,6 +83,13 @@ exports['ios-appicon-76@2x'] = {
   platforms: ['ipad'],
   minVersion: 7
 };
+exports['ios-appicon@512'] = {
+  type: 'icon',
+  path: path.join(':assets:', 'iphone', 'appicon@512.png'),
+  size: 512,
+  platforms: ['iphone','ios'],
+  minVersion: 7
+};
 
 // Spotlight & Settings icons
 exports['ios-appicon-Small'] = {


### PR DESCRIPTION
This 512px icon is created by AppC and also see this ref:
http://blog.mattstephens.co.uk/post/42021515092/splash-screen-launcher-icon-sizes-appcelerator-titanium
