### PR TITLE
added specs for iOS8 icons and splashscreens

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -55,6 +55,13 @@ exports['ios-appicon-60@2x'] = {
   platforms: ['iphone'],
   minVersion: 7
 };
+exports['ios-appicon-60@3x'] = {
+  type: 'icon',
+  path: path.join(':assets:', 'iphone', 'appicon-60@3x.png'),
+  size: 180,
+  platforms: ['iphone'],
+  minVersion: 7
+};
 exports['ios-appicon-72'] = {
   type: 'icon',
   path: path.join(':assets:', 'iphone', 'appicon-72.png'),
@@ -95,6 +102,12 @@ exports['ios-appicon-Small@2x'] = {
   type: 'icon',
   path: path.join(':assets:', 'iphone', 'appicon-Small@2x.png'),
   size: 58,
+  platforms: ['iphone','ios']
+};
+exports['ios-appicon-Small@3x'] = {
+  type: 'icon',
+  path: path.join(':assets:', 'iphone', 'appicon-Small@3x.png'),
+  size: 87,
   platforms: ['iphone','ios']
 };
 exports['ios-appicon-Small-40'] = {
@@ -150,6 +163,42 @@ exports['ios-Default-568h@2x'] = {
   width: 640,
   height: 1136,
   platforms: ['iphone']
+};
+exports['ios-Default-Portrait-667h@2x'] = {
+  type: 'splash',
+  path: path.join(':assets:', 'iphone', 'Default-Portrait-667h@2x.png'),
+  localePath: path.join('i18n', ':locale:', 'Default-Portrait-667h@2x.png'),
+  width: 750,
+  height: 1334,
+  platforms: ['iphone'],
+  orientation: 'portrait'
+};
+exports['ios-Default-Landscape-667h@2x'] = {
+  type: 'splash',
+  path: path.join(':assets:', 'iphone', 'Default-Landscape-667h@2x.png'),
+  localePath: path.join('i18n', ':locale:', 'Default-Landscape-667h@2x.png'),
+  width: 1334,
+  height: 750,
+  platforms: ['iphone'],
+  orientation: 'landscape'
+};
+exports['ios-Default-Portrait-736@3x'] = {
+  type: 'splash',
+  path: path.join(':assets:', 'iphone', 'Default-Portrait-736@3x.png'),
+  localePath: path.join('i18n', ':locale:', 'Default-Portrait-736@3x.png'),
+  width: 1242,
+  height: 2208,
+  platforms: ['iphone'],
+  orientation: 'portrait'
+};
+exports['ios-Default-Landscape-736@3x'] = {
+  type: 'splash',
+  path: path.join(':assets:', 'iphone', 'Default-Landscape-736@3x.png'),
+  localePath: path.join('i18n', ':locale:', 'Default-Landscape-736@3x.png'),
+  width: 2208,
+  height: 1242,
+  platforms: ['iphone'],
+  orientation: 'landscape'
 };
 exports['ios-Default-Portrait'] = {
   type: 'splash',


### PR DESCRIPTION
Following your commits on the web version of TiCons, I just ported the new icons and splash specs to the CLI version.
