### PR TITLE
Added asuffix option to force a suffix

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,6 +39,7 @@ program.command('splashes [input]')
 
 program.command('assets [input]')
   .description('generate missing densities for input asset(s)')
+  .option('--asuffix <suffix>', 'force a suffix')
   .action(assets);
 
 program.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ exports.assets = function(opts, callback) {
           recursive: true,
           prependDir: true,
           filter: function(itemPath, itemStat) {
-            return itemPath.match(new RegExp((inputSpec.suffix || '') + '\.(png|jpg)$'));
+            return itemPath.match(new RegExp((opts.asuffix || inputSpec.suffix || '') + '\.(png|jpg)$'));
           }
         });
 


### PR DESCRIPTION
Old projects couldn't have a @3x images.
Force to use `@2x` with `--asuffix '@2x'`
