### PR TITLE
Change targets by platforms in the module use example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ var ticons = require('ticons');
 ticons.icons({
 	input: 'icon.png',
 	outputDir: 'foo',
-	targets: ['ipad','android'],
+	platforms: ['ipad','android'],
 	classic: true
 }, function (err, output) {
 	


### PR DESCRIPTION
I was testing this inside a grunt task and the 'targets' param wasn't working. Changed to 'platforms'.
