### PR TITLE
Assets: Make resize of images precise

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ exports.assets = function (opts, callback) {
 							var convert = im(source);
 
 							// resize
-							convert.in('-resize', Math.round((spec.dpi / inputSpec.dpi) * 100) + '%');
+							convert.in('-resize', ((spec.dpi / inputSpec.dpi) * 100) + '%');
 
 							convert.write(target, function (err) {
 


### PR DESCRIPTION
Removed Math.round() to make resizing asset images precise as much as it can get.
- An image of 150px at @3x got 101px @2x (67%)
- But should be actually 100px @2x (66.66666666666666%)

Seems to work fine after some tests.