### PR TITLE
added configurable alloy base directory

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,7 @@ program
 	.option('-M, --max-dpi <dpi>', 'maximum density to generate, (default e.g. `480` or `xxhdpi`)')
 	.option('-d, --output-dir <path>', 'directory to write to')
 	.option('-a, --alloy', 'force Alloy paths, even if not detected')
+	.option('-b, --alloy-base <directory>', 'select a different alloy base directory instead of app, e.g. src')
 	.option('-p, --platforms <platforms>', 'none to detect, `all` or some of: ' + constants.platforms.join(','))
 	.option('-L, --label', 'draws the spec-name on each image for debugging')
 	.option('-s, --sdk-version <semver>', 'Titanium SDK version, overriding detected')

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,6 @@ module.exports = function config(opts, callback) {
 
 	var cfg = _.extend({
 		__cfg: true,
-
 		type: undefined,
 		cli: false,
 		input: undefined,
@@ -61,8 +60,8 @@ module.exports = function config(opts, callback) {
 		trace: false,
 		inputWidth: undefined,
 		inputHeight: undefined,
-		inputRatio: undefined
-
+		inputRatio: undefined,
+		alloyBase: 'app'
 	}, opts);
 
 	var isProject = false,
@@ -126,7 +125,7 @@ module.exports = function config(opts, callback) {
 				return next();
 			}
 
-			fs.exists(path.join(cfg.outputDir, 'app', 'config.json'), function (exists) {
+			fs.exists(path.join(cfg.outputDir, cfg.alloyBase, 'config.json'), function (exists) {
 				cfg.alloy = exists;
 
 				next();
@@ -153,7 +152,7 @@ module.exports = function config(opts, callback) {
 				if (cfg.widget) {
 					cfg.assetsDir = 'assets';
 				} else if (cfg.alloy) {
-					cfg.assetsDir = path.join('app', 'assets');
+					cfg.assetsDir = path.join(cfg.alloyBase, 'assets');
 				} else {
 					cfg.assetsDir = 'Resources';
 				}


### PR DESCRIPTION
This is needed if your alloy project is not working out of the `app` directory. 
For example, [JAST](https://github.com/dbankier/JAST).