### PR TITLE
Support Alloy 1.8+ platform new directory path

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -415,7 +415,7 @@ exports['android-appicon'] = {
 };
 exports['android-appicon-ldpi'] = {
   type: 'icon',
-  path: path.join('platform', 'android', 'res', 'drawable-ldpi', 'appicon.png'),
+  path: path.join('app', 'platform', 'android', 'res', 'drawable-ldpi', 'appicon.png'),
   size: 36,
   alpha: true,
   dpi: constants.dpi.ldpi,
@@ -423,7 +423,7 @@ exports['android-appicon-ldpi'] = {
 };
 exports['android-appicon-mdpi'] = {
   type: 'icon',
-  path: path.join('platform', 'android', 'res', 'drawable-mdpi', 'appicon.png'),
+  path: path.join('app', 'platform', 'android', 'res', 'drawable-mdpi', 'appicon.png'),
   size: 48,
   alpha: true,
   dpi: constants.dpi.mdpi,
@@ -431,7 +431,7 @@ exports['android-appicon-mdpi'] = {
 };
 exports['android-appicon-hdpi'] = {
   type: 'icon',
-  path: path.join('platform', 'android', 'res', 'drawable-hdpi', 'appicon.png'),
+  path: path.join('app', 'platform', 'android', 'res', 'drawable-hdpi', 'appicon.png'),
   size: 72,
   alpha: true,
   dpi: constants.dpi.hdpi,
@@ -439,7 +439,7 @@ exports['android-appicon-hdpi'] = {
 };
 exports['android-appicon-xhdpi'] = {
   type: 'icon',
-  path: path.join('platform', 'android', 'res', 'drawable-xhdpi', 'appicon.png'),
+  path: path.join('app', 'platform', 'android', 'res', 'drawable-xhdpi', 'appicon.png'),
   size: 96,
   alpha: true,
   dpi: constants.dpi.xhdpi,
@@ -447,7 +447,7 @@ exports['android-appicon-xhdpi'] = {
 };
 exports['android-appicon-xxhdpi'] = {
   type: 'icon',
-  path: path.join('platform', 'android', 'res', 'drawable-xxhdpi', 'appicon.png'),
+  path: path.join('app', 'platform', 'android', 'res', 'drawable-xxhdpi', 'appicon.png'),
   size: 144,
   alpha: true,
   dpi: constants.dpi.xxhdpi,
@@ -455,7 +455,7 @@ exports['android-appicon-xxhdpi'] = {
 };
 exports['android-appicon-xxxhdpi'] = {
   type: 'icon',
-  path: path.join('platform', 'android', 'res', 'drawable-xxxhdpi', 'appicon.png'),
+  path: path.join('app', 'platform', 'android', 'res', 'drawable-xxxhdpi', 'appicon.png'),
   size: 192,
   alpha: true,
   dpi: constants.dpi.xxxhdpi,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ticons",
   "preferGlobal": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Generate Titanium & Alloy icons, splash and other assets",
   "keywords": [
     "titanium",


### PR DESCRIPTION
Save Android icons in /app/platform instead of /platform

fix #50 