### PR TITLE
Add iPhone X launch screen image size

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -282,7 +282,8 @@ exports['ios-Default-Portrait-2436h@3x'] = {
   localePath: path.join(':i18n:', ':locale:', 'Default-Portrait-2436h@3x.png'),
   width: 1125,
   height: 2436,
-  platforms: ['iphone']
+  platforms: ['iphone'],
+  sdkVersion: '>=6.3.0'
 };
 exports['ios-Default-Landscape-2436h@3x'] = {
   type: 'splash',
@@ -290,7 +291,8 @@ exports['ios-Default-Landscape-2436h@3x'] = {
   localePath: path.join(':i18n:', ':locale:', 'Default-Landscape-2436h@3x.png'),
   width: 2436,
   height: 1125,
-  platforms: ['iphone']
+  platforms: ['iphone'],
+  sdkVersion: '>=6.3.0'
 };
 exports['ios-Default-Portrait'] = {
   type: 'splash',

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -276,6 +276,22 @@ exports['ios-Default-Landscape-736h@3x'] = {
   height: 1242,
   platforms: ['iphone']
 };
+exports['ios-Default-Portrait-2436h@3x'] = {
+  type: 'splash',
+  path: path.join(':assets:', 'iphone', 'Default-Portrait-2436h@3x.png'),
+  localePath: path.join(':i18n:', ':locale:', 'Default-Portrait-2436h@3x.png'),
+  width: 1125,
+  height: 2436,
+  platforms: ['iphone']
+};
+exports['ios-Default-Landscape-2436h@3x'] = {
+  type: 'splash',
+  path: path.join(':assets:', 'iphone', 'Default-Landscape-2436h@3x.png'),
+  localePath: path.join(':i18n:', ':locale:', 'Default-Landscape-2436h@3x.png'),
+  width: 2436,
+  height: 1125,
+  platforms: ['iphone']
+};
 exports['ios-Default-Portrait'] = {
   type: 'splash',
   path: path.join(':assets:', 'iphone', 'Default-Portrait.png'),

--- a/test/splashes.js
+++ b/test/splashes.js
@@ -137,6 +137,44 @@ describe('splashes', function() {
 
     });
 
+    it('generates iPhone X format', function(done) {
+
+      ticons.splashes({
+        input: path.join(__dirname, 'splash.png'),
+        outputDir: tmpDir,
+        alloy: true,
+        platforms: ['ios'],
+        sdkVersion: '6.3.0'
+      }, function(err, output) {
+
+        if (err) {
+          return done(new Error(err));
+        }
+
+        _.sortBy(output, _.identity).should.be.eql(_.sortBy({
+          "Default-568h@2x": path.join(tmpDir,"/app/assets/iphone/Default-568h@2x.png"),
+          "Default-667h@2x": path.join(tmpDir,"/app/assets/iphone/Default-667h@2x.png"),
+          "Default-Landscape-736h@3x": path.join(tmpDir,"/app/assets/iphone/Default-Landscape-736h@3x.png"),
+          "Default-Landscape-2436h@3x": path.join(tmpDir,"/app/assets/iphone/Default-Landscape-2436h@3x.png"),
+          "Default-Landscape": path.join(tmpDir,"/app/assets/iphone/Default-Landscape.png"),
+          "Default-Landscape@2x": path.join(tmpDir,"/app/assets/iphone/Default-Landscape@2x.png"),
+          "Default-Portrait-736@3x": path.join(tmpDir,"/app/assets/iphone/Default-Portrait-736h@3x.png"),
+          "Default-Portrait-2436@3x": path.join(tmpDir,"/app/assets/iphone/Default-Portrait-2436h@3x.png"),
+          "Default-Portrait": path.join(tmpDir,"/app/assets/iphone/Default-Portrait.png"),
+          "Default-Portrait@2x": path.join(tmpDir,"/app/assets/iphone/Default-Portrait@2x.png"),
+          "Default@2x": path.join(tmpDir,"/app/assets/iphone/Default@2x.png"),
+        }, _.identity));
+
+        should(_.every(output, function(output, name) {
+          return fs.existsSync(output);
+        })).be.true;
+
+        done();
+
+      });
+
+    });
+
     after(function() {
       fs.deleteDirSync(tmpDir);
     });


### PR DESCRIPTION
Although it's not the adviced strategy, the iPhone X still supports static images for the launch screen. This PR adds support for generating that format.