### PR TITLE
Remove usage of update-notifier from cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,15 +5,10 @@
 
 var _ = require('underscore'),
 	program = require('commander'),
-	updateNotifier = require('update-notifier'),
 	pkg = require('./package.json'),
 	ticons = require('./'),
 	constants = require('./lib/constants'),
 	logger = require('./lib/logger');
-
-var notifier = updateNotifier({
-	pkg: pkg
-});
 
 program
 	.version(pkg.version, '-v, --version')
@@ -59,14 +54,10 @@ program.command('assets [input]')
 program.parse(process.argv);
 
 if (program.args.length === 0 || typeof program.args[program.args.length - 1] === 'string') {
-	notifier.update && notifier.notify();
-
 	program.help();
 }
 
 function assets(input, env) {
-	notifier.update && notifier.notify();
-
 	var options = _filterOptions(env);
 
 	options.cli = true;
@@ -82,8 +73,6 @@ function assets(input, env) {
 }
 
 function icons(input, env) {
-	notifier.update && notifier.notify();
-
 	var options = _filterOptions(env);
 
 	options.cli = true;
@@ -99,8 +88,6 @@ function icons(input, env) {
 }
 
 function adaptiveicons(input, env) {
-	notifier.update && notifier.notify();
-
 	var options = _filterOptions(env);
 
 	options.cli = true;
@@ -116,8 +103,6 @@ function adaptiveicons(input, env) {
 }
 
 function splashes(input, env) {
-	notifier.update && notifier.notify();
-
 	var options = _filterOptions(env);
 
 	options.cli = true;

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "gm": "~1.23.1",
     "semver": "^5.0.1",
     "sindresorhus": "^3.0.2",
-    "underscore": "^1.5.2",
-    "update-notifier": "^7.0.0"
+    "underscore": "^1.5.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Damn plugin always causes issues from time to time anyway, and it isn't like this package is getting new important releases anyway :joy: 

I tried installing the lib in multiple node versions (14, 16, 20) and they all caused different issues with that lib, the latest simply being the lib wasn't being found, even if it got correctly installed :man_shrugging: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic update checking and notifications from the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->